### PR TITLE
Fix: Improve error handling for blank page scenario

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,10 @@
 document.addEventListener('DOMContentLoaded', () => {
     async function loadFragment(fragmentPath, placeholderId) {
         try {
+            // Note: Fetching local files (file:///) can be unreliable in some browsers due
+            // to security restrictions (CORS-like behavior). For consistent behavior
+            // and to avoid potential loading issues, it's recommended to serve these
+            // files via a local web server during development.
             const response = await fetch(fragmentPath);
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status} for ${fragmentPath}`);
@@ -261,11 +265,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 const targetSection = document.getElementById(sectionId);
                 if (!targetSection) {
                     console.error(`Section with ID ${sectionId} not found in the DOM.`);
-                    // Try to show default section if target is not found, to prevent blank page
-                    if (sectionId !== 'accueil') {
-                        showSection('accueil', instant);
+                    const mainContent = document.getElementById('main-content');
+                    if (mainContent) {
+                        mainContent.innerHTML = `<p style="text-align: center; padding: 20px; font-size: 18px; color: orange;">Error: The requested content section ('${sectionId}') could not be found or displayed.</p>`;
                     }
-                    return;
+                    // If the missing section is not 'accueil', try to show 'accueil'.
+                    // If 'accueil' is also missing, the next call will handle displaying the error for 'accueil'.
+                    if (sectionId !== 'accueil') {
+                        showSection('accueil', instant); 
+                    }
+                    return; // Important to stop further processing if section not found
                 }
 
                 // Check if sections NodeList is populated
@@ -403,6 +412,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         } catch (error) {
             console.error('Error loading one or more fragments:', error);
+            const mainContent = document.getElementById('main-content');
+            if (mainContent) {
+                mainContent.innerHTML = '<p style="text-align: center; padding: 20px; font-size: 18px; color: red;">Error: Could not load page content. This can happen if you are opening the file directly from your computer. For best results, please try accessing it through a web server. If the problem persists, please contact support.</p>';
+            }
         }
     }
 


### PR DESCRIPTION
Addresses issue where the page could appear blank if content fragments failed to load, particularly when accessed via file:/// protocol.

Changes:
- Modified index.html to display a user-visible error message in the main content area if fragment loading fails (e.g., due to fetch restrictions).
- Made the showSection function more resilient: if a target section (including the default 'accueil') is not found, a specific error message is now displayed on the page.
- Added a comment in the JavaScript to warn developers about potential issues with fetch() and file:/// URLs, recommending a local server for testing.

These changes ensure that you receive feedback directly on the page if critical content cannot be loaded or displayed, rather than seeing a completely blank page without explanation.