### PR TITLE
Fix: Standardize fragment paths in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,14 +214,14 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const fragmentsToLoad = [
-        { path: '_header.html', placeholder: 'header-placeholder' },
-        { path: '_accueil.html', placeholder: 'accueil-placeholder' },
-        { path: '_apropos.html', placeholder: 'a-propos-placeholder' },
-        { path: '_services.html', placeholder: 'services-placeholder' },
-        { path: '_portfolio.html', placeholder: 'portfolio-placeholder' },
-        { path: '_contact.html', placeholder: 'contact-placeholder' },
-        { path: '_avenir.html', placeholder: 'a-venir-placeholder' },
-        { path: '_footer.html', placeholder: 'footer-placeholder' }
+        { path: './_header.html', placeholder: 'header-placeholder' },
+        { path: './_accueil.html', placeholder: 'accueil-placeholder' },
+        { path: './_apropos.html', placeholder: 'a-propos-placeholder' },
+        { path: './_services.html', placeholder: 'services-placeholder' },
+        { path: './_portfolio.html', placeholder: 'portfolio-placeholder' },
+        { path: './_contact.html', placeholder: 'contact-placeholder' },
+        { path: './_avenir.html', placeholder: 'a-venir-placeholder' },
+        { path: './_footer.html', placeholder: 'footer-placeholder' }
     ];
 
     async function loadAllFragments() {


### PR DESCRIPTION
I've updated the paths for HTML fragments in the `fragmentsToLoad` array within `index.html` to be explicitly relative (e.g., using `./_header.html` instead of `_header.html`).

This change is a minor safeguard to ensure consistent path resolution, although the primary cause of 404 errors on the associated GitHub Pages site is likely related to deployment or configuration settings for that site.