### PR TITLE
Fix: Re-initialize Lucide icons after section visibility changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 // Scroll en haut de la page
                 window.scrollTo(0, 0);
                 
+                // Re-initialize Lucide icons after section is made visible
+                if (window.lucide && typeof window.lucide.createIcons === 'function') {
+                    lucide.createIcons();
+                    console.log(`Lucide icons re-initialized specifically for section: ${sectionId}`);
+                }
+                
                 // Clear animation flag after transition (adjust timeout if needed)
                 setTimeout(() => {
                     isAnimating = false;


### PR DESCRIPTION
To address issues where Lucide icons might not render correctly if they are processed while their parent section is hidden (e.g., opacity: 0), this change adds a call to `lucide.createIcons()` within the `showSection` function.

This ensures that icons are processed or re-processed after the target section becomes fully visible, potentially resolving rendering glitches for dynamically loaded content.