### PR TITLE
Feat: Integrate user-provided icons for Portfolio and ATC

### DIFF
--- a/_apropos.html
+++ b/_apropos.html
@@ -18,7 +18,7 @@
             <!-- Expertise ATC -->
             <div class="bg-white rounded-xl p-6 md:p-8 shadow-lg hover:shadow-xl transition-shadow">
                 <div class="flex items-center mb-4">
-                    <i data-lucide="landmark" class="w-8 h-8 mr-3"></i>
+                    <img src="images/control-tower.png" alt="Control Tower Icon" class="w-8 h-8 mr-3">
                     <h3 class="text-xl md:text-2xl font-semibold text-gray-800">Contrôleur Aérien Professionnel</h3>
                 </div>
                 <p class="text-gray-700 leading-relaxed">

--- a/_portfolio.html
+++ b/_portfolio.html
@@ -1,6 +1,6 @@
 <section id="portfolio" class="py-16 md:py-20 bg-white">
     <div class="container mx-auto px-4 md:px-6">
-        <h2 class="section-title text-yellow-600 mb-3 md:mb-4">Mon Portfolio</h2>
+        <h2 class="section-title text-yellow-600 mb-3 md:mb-4 flex items-center justify-center"><img src="images/portfolio-folder.png" alt="Portfolio Icon" class="w-8 h-8 mr-3">Mon Portfolio</h2>
         <p class="text-center text-lg md:text-xl text-gray-600 mb-10 md:mb-12 max-w-3xl mx-auto leading-relaxed">
             Découvrez quelques exemples de mon travail.</p>
         <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-10">


### PR DESCRIPTION
- I updated the 'Contrôleur Aérien Professionnel' section in _apropos.html to use your uploaded 'images/control-tower.png', replacing the placeholder Lucide icon.
- I added your uploaded 'images/portfolio-folder.png' next to the 'Mon Portfolio' section title in _portfolio.html for enhanced visual context.